### PR TITLE
Removed data from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,3 @@ $RECYCLE.BIN/
 **/__pycache__/
 *.py[cod]
 *$py.class
-
-# Cache
-data*

--- a/services/control-dashboard/datasources/datasource.yml
+++ b/services/control-dashboard/datasources/datasource.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: InfluxDB
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    secureJsonData:
+      token: V_g3T7i-QyHF3e_uDvBE05MRVKd-234xHwLDACXuw457UnhEBFOVP1Cr5IVb1EclrG6IRS5uBjMbOhMidnu8kA==
+    jsonData:
+      version: Flux
+      organization: jarvil
+      defaultBucket: jarvil-bucket


### PR DESCRIPTION
The data path in the gitignore prevented the datasource provisioning for grafana from being added to git. It is not necessary anymore anyways.